### PR TITLE
CASMPET-4619  ncnPostgresHealthChecks pass/fail

### DIFF
--- a/ncnPostgresHealthChecks.sh
+++ b/ncnPostgresHealthChecks.sh
@@ -18,14 +18,14 @@ lagWarning=0
 function printErrorLogs() {
     echo; echo "--- Error Logs for $c_ns \"Leader Pod\" $leader --- "
         kubectl logs -n $c_ns $leader postgres | awk '{print $line}' \
-            | egrep "ERROR" | egrep -v "NewConnection|bootstrapping|get_cluster|IncompleteRead\(0 bytes read\)" \
+            | egrep "ERROR" | egrep -v "get_cluster|IncompleteRead\(0 bytes read\)" \
             | sort -u | tail -n 50
 
     for o in $other
     do
         echo; echo "--- Error Logs for $c_ns$podDescribe pod $o --- "
         kubectl logs -n $c_ns $o postgres | awk '{print $line}' \
-            | egrep "ERROR" | egrep -v "NewConnection|bootstrapping|get_cluster|IncompleteRead\(0 bytes read\)" \
+            | egrep "ERROR" | egrep -v "get_cluster|IncompleteRead\(0 bytes read\)" \
             | sort -u | tail -n 50
     done
 


### PR DESCRIPTION
### Summary and Scope
* CASMPET-4619

    Changed ncnPostgresHealthChecks.sh to be pass fail. Included check to make sure lag is not 'unknown'. Changed output of postgres pod logs to only print 'ERROR' statements so user does not need to parse hundreds of lines of 'INFO'.

### Issues and Related PRs

Resolves CASMPET-4649
Related to CASMPET-4648. Added a warning for if lag is 'unknown' because this is possibly an unhealthy state.

### Testing

Tested on:
vShasta
Groot

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) NA
Was a fresh Install tested? Y/N   If not, Why? NA
Was an Upgrade tested?      Y/N   If not, Why? NA
Was a Downgrade tested?     Y/N.  If not, Why? NA
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?

This is a change to platform health checks. Read only script.

### Risks and Mitigations

Requires: