### PR TITLE
CASMISNT-2882  etcd restore/rebuild will create /root/etcd dir

### DIFF
--- a/etcd_restore_rebuild_util/etcd_restore_rebuild.sh
+++ b/etcd_restore_rebuild_util/etcd_restore_rebuild.sh
@@ -23,7 +23,7 @@ one_week_sec=604800
 
 main() {
     #create /root/etcd directory if it doesn't exist
-    if [[ ! -d /root/etcd ]]; then mkdir /root/etcd; fi
+    if [[ ! -d /root/etcd ]]; then mkdir -p /root/etcd; fi
     
     if [[ $restore_all == 1 ]]
     then


### PR DESCRIPTION
### Summary and Scope
* CASMINST-2882

    etcd_rebuild_restore.sh will create /root/etcd directory if it doesn't exist. Additionally, fixed minor 'print' errors.

### Issues and Related PRs

Relates to CASMINST-2529

### Testing

Tested on:
vShasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) NA
Was a fresh Install tested? Y/N   If not, Why? NA
Was an Upgrade tested?      Y/N   If not, Why? NA
Was a Downgrade tested?     Y/N.  If not, Why? NA
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?


### Risks and Mitigations

Requires: