### PR TITLE
CASMPET-5030

### DIFF
--- a/platform-utils.spec
+++ b/platform-utils.spec
@@ -26,14 +26,18 @@ the /opt/cray/platform-utils directory.
 %defattr(755, root, root)
 %dir %{utils_dir}
 %dir %{utils_dir}/s3
+%dir %{utils_dir}/etcd_restore_rebuild_util
 %{utils_dir}/ncnGetXnames.sh
 %{utils_dir}/ncnHealthChecks.sh
 %{utils_dir}/ncnPostgresHealthChecks.sh
 %{utils_dir}/detect_cpu_throttling.sh
 %{utils_dir}/move_pod.sh
+%{utils_dir}/ceph-service-status.sh
 %{utils_dir}/s3/download-file.py
 %{utils_dir}/s3/list-objects.py
 %{utils_dir}/spire/fix-spire-on-storage.sh
+%{utils_dir}/etcd_restore_rebuild_util/edit_yaml_for_rebuild.py
+%{utils_dir}/etcd_restore_rebuild_util/etcd_restore_rebuild.sh
 
 %prep
 %setup -q
@@ -44,11 +48,15 @@ the /opt/cray/platform-utils directory.
 install -m 755 -d %{buildroot}%{utils_dir}/
 install -m 755 -d %{buildroot}%{utils_dir}/s3
 install -m 755 -d %{buildroot}%{utils_dir}/spire
+install -m 755 -d %{buildroot}%{utils_dir}/etcd_restore_rebuild_util
 install -m 755 ncnGetXnames.sh %{buildroot}%{utils_dir}
 install -m 755 ncnHealthChecks.sh %{buildroot}%{utils_dir}
 install -m 755 ncnPostgresHealthChecks.sh %{buildroot}%{utils_dir}
 install -m 755 detect_cpu_throttling.sh %{buildroot}%{utils_dir}
 install -m 755 move_pod.sh %{buildroot}%{utils_dir}
+install -m 755 ceph-service-status.sh %{buildroot}%{utils_dir}
 install -m 755 s3/list-objects.py %{buildroot}%{utils_dir}/s3
 install -m 755 s3/download-file.py %{buildroot}%{utils_dir}/s3
 install -m 755 spire/fix-spire-on-storage.sh %{buildroot}%{utils_dir}/spire
+install -m 755 etcd_restore_rebuild_util/edit_yaml_for_rebuild.py %{buildroot}%{utils_dir}/etcd_restore_rebuild_util
+install -m 755 etcd_restore_rebuild_util/etcd_restore_rebuild.sh %{buildroot}%{utils_dir}/etcd_restore_rebuild_util


### PR DESCRIPTION
### Summary and Scope
* CASMPET-5030

     Add etcd_restore_rebuild_util and ceph-service-status.sh to platform-utils.spec so they will be included in the RPM that installs platform utility.

### Issues and Related PRs


### Testing

Tested on:

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) NA
Was a fresh Install tested? Y/N   If not, Why? NA
Was an Upgrade tested?      Y/N   If not, Why? NA
Was a Downgrade tested?     Y/N.  If not, Why? NA
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?


### Risks and Mitigations

Requires:
