### PR TITLE
Run ceph commands on master node in case storage node(s) down

### DIFF
--- a/ncnHealthChecks.sh
+++ b/ncnHealthChecks.sh
@@ -106,9 +106,6 @@ get_nodes() {
     sNcnNodes=$(ssh $sshOptions $firstMaster ceph node ls osd | \
                     jq -r 'keys | join(" ")')
 
-    # Get first storage node:
-    firstStorage=$(echo $sNcnNodes | awk '{print $1}')
-
     ncnNodes=${mNcnNodes}${wNcnNodes}$sNcnNodes
     echo "=== NCN Master nodes: ${mNcnNodes}==="
     echo "=== NCN Worker nodes: ${wNcnNodes}==="
@@ -140,10 +137,10 @@ ceph_health_status() {
     echo "=== Verify \"health: HEALTH_OK\" Status. ==="
     echo "=== At times a status of HEALTH_WARN, too few PGs per OSD, and/or large \
 omap objects, may be okay. ==="
-    echo "=== date; ssh $firstStorage ceph -s; ==="
+    echo "=== date; ssh $firstMaster ceph -s; ==="
     date
-    ssh $sshOptions $firstStorage ceph -s
-    health_ok=$(ssh $sshOptions $firstStorage ceph -s | grep 'health: HEALTH_OK')
+    ssh $sshOptions $firstMaster ceph -s
+    health_ok=$(ssh $sshOptions $firstMaster ceph -s | grep 'health: HEALTH_OK')
     if [[ -z $health_ok ]]
     then
         echo " --- FAILED --- Ceph's health status is not \"HEALTH_OK\".";


### PR DESCRIPTION
## Summary and Scope

Remove needless ssh to a storage node to get ceph status.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2693](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2693)

## Testing

Craystack:

ncn-m001:~ # /opt/cray/platform-utils/ncnHealthChecks.sh -s ceph_health_status
=== NCN Master nodes: ncn-m001 ncn-m002 ncn-m003 ===
=== NCN Worker nodes: ncn-w001 ncn-w002 ncn-w003 ===
=== NCN Storage nodes: ncn-s001 ncn-s002 ncn-s003 ===

**************************************************************************

=== Check Ceph Health Status. ===
=== Verify "health: HEALTH_OK" Status. ===
=== At times a status of HEALTH_WARN, too few PGs per OSD, and/or large omap objects, may be okay. ===
=== date; ssh ncn-m001 ceph -s; ===
Fri 05 Nov 2021 01:34:58 PM UTC
  cluster:
    id:     07ab13c8-3d82-11ec-8d34-fa163ee58eb1
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum ncn-s001,ncn-s002,ncn-s003 (age 22h)
    mgr: ncn-s003.anlluh(active, since 22h), standbys: ncn-s001.znhmoo, ncn-s002.slusih
    mds: cephfs:1 {0=cephfs.ncn-s003.fphbpa=up:active} 1 up:standby-replay 1 up:standby
    osd: 3 osds: 3 up (since 22h), 3 in (since 22h)
    rgw: 3 daemons active (site1.zone1.ncn-s001.yjcict, site1.zone1.ncn-s002.knzhym, site1.zone1.ncn-s003.yfvied)

  task status:

  data:
    pools:   8 pools, 177 pgs
    objects: 649 objects, 39 KiB
    usage:   3.1 GiB used, 72 GiB / 75 GiB avail
    pgs:     177 active+clean

  io:
    client:   1.2 KiB/s rd, 2 op/s rd, 0 op/s wr

 --- PASSED ---

### Tested on:

  * `Craystack`

### Test description:

Execution

## Risks and Mitigations

Low

## Pull Request Checklist

N/A


