### PR TITLE
CASMINST-3621 : BREAK/FIX: Etcd backup restore failed

### DIFF
--- a/etcd_restore_rebuild_util/etcd_restore_rebuild.sh
+++ b/etcd_restore_rebuild_util/etcd_restore_rebuild.sh
@@ -131,8 +131,6 @@ restore() {
     if [[ $pods_started == 'true' ]]
     then
         echo "Successfully restored ${etcd_cluster}"
-        # delete the etcd custom resource
-        kubectl -n $namespace delete etcdrestore.etcd.database.coreos.com/${etcd_cluster}
     elif [[ $pods_started == 'errorStarting' ]]
     then
         echo "Error: Attempted to restore ${etcd_cluster} but not all pods are 'ready'."
@@ -333,8 +331,8 @@ get_latest_backup() {
         then
             most_recent_backup=$backup_instance
             backup_date=$(echo $backup_instance | cut -d '_' -f 3 | sed "s/-/ /3")
-            if [[ -z $backup_date ]]; then backup_sec=0;
-            else backup_sec=$(date -d "${backup_date}" "+%s"); fi
+            if [[ -z $backup_date ]]; then most_recent_backup_sec=0;
+            else most_recent_backup_sec=$(date -d "${backup_date}" "+%s"); fi
         else
             backup_date=$(echo $backup_instance | cut -d '_' -f 3 | sed "s/-/ /3")
             if [[ -z $backup_date ]]; then backup_sec=0;


### PR DESCRIPTION
## Summary and Scope
* Fixed race condition in restore script that was caused by deleting of the crd before the pods were restarted after restore. A delete of the crd is already being done before the restore starts and thus is not also needed after the restore completes.
* Fixed get_latest_backup to set the most_recent_backup_sec for first backup_instance.

This change is backward compatible

## Issues and Related PRs

* Resolves [CASMINST-3621](https://connect.us.cray.com/jira/browse/CASMINST-3621)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required NA
* Merge with/before/after NA

## Testing

Verified restore succeeds

### Tested on:

drax and vshasta

### Test description:
```
ncn-m001: # ./etcd_restore_rebuild.sh -s cray-bss-etcd
The following etcd clusters will be restored/rebuilt:
cray-bss-etcd
You will be accepting responsibility for any missing data if there is a restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
Proceed restoring/rebuilding? (yes/no)
yes
Proceeding: restoring/rebuilding etcd clusters.

 ----- Restoring from cray-bss/etcd.backup_v1993_2021-12-01-19:22:08
etcdrestore.etcd.database.coreos.com "cray-bss-etcd" deleted
etcdrestore.etcd.database.coreos.com/cray-bss-etcd created
- 3/3  Running
Successfully restored cray-bss-etcd
```
```
ncn-m001: # kubectl get pods -A | grep cray-bss                                                                                                                                                                  

services            cray-bss-5bfd6c776-dg2df                                          2/2     Running     0          12h
services            cray-bss-5bfd6c776-fnnts                                          2/2     Running     0          12h
services            cray-bss-5bfd6c776-sdnhs                                          2/2     Running     0          12h
services            cray-bss-etcd-mpbnwvmbzq                                          1/1     Running     0          13m
services            cray-bss-etcd-npw5btzkg6                                          1/1     Running     0          13m
services            cray-bss-etcd-wb2kz4fj6f                                          1/1     Running     0          14m
services            cray-bss-wait-for-etcd-1-kxw2q                                    0/1     Completed   0          12h
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

NA

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

