### PR TITLE
CASMINST-5379: etcd restore rebuild bad refrence

### DIFF
--- a/etcd_restore_rebuild_util/etcd_restore_rebuild.sh
+++ b/etcd_restore_rebuild_util/etcd_restore_rebuild.sh
@@ -367,9 +367,9 @@ rebuild() {
     echo "Deployment and etcd cluster objects captured in yaml file"
     
     # edit yaml
-    python3 edit_yaml_for_rebuild.py $cluster
+    python3 /opt/cray/platform-utils/etcd_restore_rebuild_util/edit_yaml_for_rebuild.py $cluster
     if [[ $? != 0 ]]; then echo "Error: not able to edit yaml at /root/etcd/${cluster}."; return; fi
-    python3 edit_yaml_for_rebuild.py $etcd_cluster
+    python3 /opt/cray/platform-utils/etcd_restore_rebuild_util/edit_yaml_for_rebuild.py $etcd_cluster
     if [[ $? != 0 ]]; then echo "Error: not able to edit yaml at /root/etcd/${etcd_cluster}."; return; fi
     echo "yaml files edited"
     


### PR DESCRIPTION
## Summary and Scope

This was a bugfix to fix a bad reference to the python script needed by etcd_restore_rebuild_utill. 
This will need a backport to 1.3 as the doc is changed there as well.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5379](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5379)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No risk as it fixes a regression in the script. 


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

