### PR TITLE
CASMPET-7713 - Add script to join fabric manager nodes to spire

### DIFF
--- a/platform-utils.spec
+++ b/platform-utils.spec
@@ -37,6 +37,7 @@ the /opt/cray/platform-utils directory.
 %{utils_dir}/s3/download-file.py
 %{utils_dir}/s3/list-objects.py
 %{utils_dir}/spire/fix-spire-on-storage.sh
+%{utils_dir}/spire/fix-spire-on-fmn.sh
 %{utils_dir}/spire/spire-enable-tpm.sh
 %{utils_dir}/spire/spire-disable-tpm.sh
 %{utils_dir}/etcd/etcd_restore_rebuild.sh
@@ -62,6 +63,7 @@ install -m 755 grafterm.sh %{buildroot}%{utils_dir}
 install -m 755 s3/list-objects.py %{buildroot}%{utils_dir}/s3
 install -m 755 s3/download-file.py %{buildroot}%{utils_dir}/s3
 install -m 755 spire/fix-spire-on-storage.sh %{buildroot}%{utils_dir}/spire
+install -m 755 spire/fix-spire-on-fmn.sh %{buildroot}%{utils_dir}/spire
 install -m 755 spire/spire-enable-tpm.sh %{buildroot}%{utils_dir}/spire
 install -m 755 spire/spire-disable-tpm.sh %{buildroot}%{utils_dir}/spire
 install -m 755 etcd/etcd_restore_rebuild.sh %{buildroot}%{utils_dir}/etcd

--- a/spire/fix-spire-on-fmn.sh
+++ b/spire/fix-spire-on-fmn.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spire/fix-spire-on-fmn.sh
+++ b/spire/fix-spire-on-fmn.sh
@@ -99,7 +99,7 @@ for node in $nodes; do
 		fi
 		echo "$node is being joined to spire."
 		XNAME="$(sshnh "$node" cat /proc/cmdline | sed 's/.*xname=\([A-Za-z0-9]*\).*/\1/')"
-		TOKEN="$(kubectl exec -n spire "$POD" --container registration-server -- curl -k -X POST -d type=storage\&xname="$XNAME" "$URL" | tr ':' '=' | tr -d '"{}')"
+		TOKEN="$(kubectl exec -n spire "$POD" --container registration-server -- curl -k -X POST -d type=fmn\&xname="$XNAME" "$URL" | tr ':' '=' | tr -d '"{}')"
 		sshnh "$node" "echo $TOKEN > ${jointoken}"
 		kubectl get configmap -n spire cray-spire-ncn-config -o jsonpath='{.data.spire-agent\.conf}' | sed "s/server_address.*/server_address = \"$LOADBALANCERIP\"/" | sshnh "$node" "cat > ${spireagent}"
 		kubectl get configmap -n spire cray-spire-bundle -o jsonpath='{.data.bundle\.crt}' | sshnh "$node" "cat > ${spirebundle}"

--- a/spire/fix-spire-on-fmn.sh
+++ b/spire/fix-spire-on-fmn.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+RETRY=0
+MAX_RETRIES=30
+RETRY_SECONDS=10
+
+until kubectl exec -itn spire cray-spire-server-0 --container spire-server -- ./bin/spire-server healthcheck | grep -q 'Server is healthy'; do
+	if [[ "$RETRY" -lt "$MAX_RETRIES" ]]; then
+		RETRY="$((RETRY + 1))"
+		echo "cray-spire-server is not ready. Will retry after $RETRY_SECONDS seconds. ($RETRY/$MAX_RETRIES)"
+	else
+		echo "cray-spire-server did not start after $(echo "$RETRY_SECONDS" \* "$MAX_RETRIES" | bc) seconds."
+		exit 1
+	fi
+	sleep "$RETRY_SECONDS"
+done
+
+URL="https://cray-spire-tokens.spire:54440/api/token"
+POD=$(kubectl get pods -n spire | grep cray-spire-server | grep Running | awk 'NR==1{print $1}')
+LOADBALANCERIP=$(kubectl get service -n spire cray-spire-local --no-headers --output=jsonpath='{.spec.loadBalancerIP}')
+
+RETRY=0
+until [[ ! -z $POD && ! -z $LOADBALANCERIP ]]; do
+	if [[ "$RETRY" -lt "$MAX_RETRIES" ]]; then
+		RETRY="$((RETRY + 1))"
+		echo "Either POD or LOADBALANCERIP was not set. Will retry after $RETRY_SECONDS seconds. ($RETRY/$MAX_RETRIES)"
+	else
+		if [[ -z $POD ]]; then
+			echo "No cray-spire-server pod is running after $(echo "$RETRY_SECONDS" \* "$MAX_RETRIES" | bc) seconds."
+		fi
+		if [[ -z $LOADBALANCERIP ]]; then
+			echo "cray-spire-local service is not ready after $(echo "$RETRY_SECONDS" \* "$MAX_RETRIES" | bc) seconds."
+		fi
+		exit 1
+	fi
+	sleep "$RETRY_SECONDS"
+	POD=$(kubectl get pods -n spire | grep cray-spire-server | grep Running | awk 'NR==1{print $1}')
+	LOADBALANCERIP=$(kubectl get service -n spire cray-spire-local --no-headers --output=jsonpath='{.spec.loadBalancerIP}')
+done
+
+function sshnh() {
+	/usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+}
+
+if hostname | grep -q 'pit'; then
+	echo "This script is not supported on pit nodes. Please run it on ncn-m002."
+	exit 1
+fi
+
+set -euo pipefail
+
+nodes=$(cray sls hardware list --format json | jq -r '.[] | select(.ExtraProperties.SubRole == "FabricManager") | .ExtraProperties.Aliases[]')
+if [ -z "$nodes" ]; then
+	echo "Error: No FabricManager nodes found" >&2
+        exit 1
+fi
+
+# Make changes to the installation prefix a bit easier with vars
+prefix=/var/lib/spire
+conf="${prefix}/conf"
+socket="${prefix}/agent.sock"
+datadir="${prefix}/data"
+svidkey="${datadir}/svid.key"
+bundleder="${prefix}/bundle.der"
+agentsvidder="${prefix}/agent_svid.der"
+jointoken="${conf}/join_token"
+spireagent="${conf}/spire-agent.conf"
+spirebundle="${conf}/bundle.crt"
+
+for node in $nodes; do
+	if sshnh "$node" spire-agent healthcheck -socketPath="${socket}" 2>&1 | grep -q "healthy"; then
+		echo "$node is already joined to spire and is healthy."
+	else
+		if sshnh "$node" ls "${svidkey}" >/dev/null 2>&1; then
+			echo "$node was once joined to spire. Cleaning up old files"
+			sshnh "$node" rm "${svidkey}" "${bundleder}" "${agentsvidder}" || true
+		fi
+		echo "$node is being joined to spire."
+		XNAME="$(sshnh "$node" cat /proc/cmdline | sed 's/.*xname=\([A-Za-z0-9]*\).*/\1/')"
+		TOKEN="$(kubectl exec -n spire "$POD" --container registration-server -- curl -k -X POST -d type=storage\&xname="$XNAME" "$URL" | tr ':' '=' | tr -d '"{}')"
+		sshnh "$node" "echo $TOKEN > ${jointoken}"
+		kubectl get configmap -n spire cray-spire-ncn-config -o jsonpath='{.data.spire-agent\.conf}' | sed "s/server_address.*/server_address = \"$LOADBALANCERIP\"/" | sshnh "$node" "cat > ${spireagent}"
+		kubectl get configmap -n spire cray-spire-bundle -o jsonpath='{.data.bundle\.crt}' | sshnh "$node" "cat > ${spirebundle}"
+		sshnh "$node" systemctl enable spire-agent
+		sshnh "$node" systemctl start spire-agent
+	fi
+done


### PR DESCRIPTION
## Summary and Scope

Added a new script `fix-spire-on-fmn.sh` to join Fabric Manager nodes to the Spire authentication system. This script is modeled after the existing `fix-spire-on-storage.sh` script but targets FabricManager nodes (identified by `SubRole == "FabricManager"` in SLS) instead of Ceph storage nodes. The script automates the process of registering these nodes with Spire, including health checks, token generation, configuration deployment, and service enablement.

This is a **backwards compatible** new feature that adds functionality without impacting existing behavior.

## Issues and Related PRs

* Resolves [CASMPET-7713](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-7713)

## Testing

### Tested on:

  * surtur

### Test description:

- **Script execution**: Verified the script successfully identifies Fabric Manager nodes from SLS and joins them to Spire
- **Health checks**: Confirmed the script properly waits for Spire server readiness before proceeding
- **Re-run safety**: Tested that the script correctly identifies already-joined nodes and skips them
- **Cleanup logic**: Verified that nodes previously joined to Spire are properly cleaned up and re-joined
- **Error handling**: Tested error scenarios including missing FabricManager nodes and unavailable Spire services
- Were continuous integration tests run? _[Standard CI/CD pipeline would run if applicable]_
- Was upgrade tested? N/A - New script addition only
- Was downgrade tested? N/A - New script addition only
- Were new tests created? No

## Risks and Mitigations

**Risks:**
- Script uses a dedicated registration type (type=fmn) for Fabric Manager nodes in token generation
- Requires SSH access to Fabric Manager nodes
- Must be run from a management node (not PIT)

**Mitigations:**
- Script includes comprehensive health checks and retry logic
- Safely handles already-joined nodes to allow re-runs
- Clear error messages guide users when prerequisites aren't met

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [x] Copyrights updated (MIT License with HPE copyright included)
- [x] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] RPM spec file updated to include new script
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable